### PR TITLE
Added gzip library

### DIFF
--- a/workflow_genbank_ingest/Snakefile
+++ b/workflow_genbank_ingest/Snakefile
@@ -2,6 +2,7 @@
 
 import datetime
 import os
+import gzip
 
 from pathlib import Path
 


### PR DESCRIPTION
When running the Genbank ingest version of the pipeline I ran into the following error:

```
InputFunctionException in line 116 of /home/CSCScience.ca/apetkau/workspace/covidcg-1.4/workflow_genbank_ingest/Snakefile:
Error:
  NameError: name 'gzip' is not defined
Wildcards:

Traceback:
  File "/home/CSCScience.ca/apetkau/workspace/covidcg-1.4/workflow_genbank_ingest/Snakefile", line 105, in get_changed_chunks
  File "/home/CSCScience.ca/apetkau/workspace/covidcg-1.4/workflow_genbank_ingest/Snakefile", line 70, in get_num_seqs
Removing output files of failed job chunk_data since they might be corrupted:
../data_genbank/fasta_temp, ../data_genbank/metadata_dirty.csv
Shutting down, this might take some time.
Exiting because a job execution failed. Look above for error message
```

Adding `import gzip` fixes this issue.