### PR TITLE
Fixed up import/added samtools dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,6 +11,7 @@ dependencies:
   - bowtie2=2.4.1
   - pip=20.1.1
   - snakemake=5.20.1
+  - samtools=1.10
   - pip:
       - pysam==0.15.4
       # For cloud function development

--- a/workflow_main/scripts/write_reference_files.py
+++ b/workflow_main/scripts/write_reference_files.py
@@ -8,6 +8,8 @@ Author: Albert Chen - Vector Engineering Team (chena@broadinstitute.org)
 import json
 import pandas as pd
 
+from scripts.fasta import read_fasta_file
+
 
 def write_reference_files(reference_fasta, primers_csv, reference_json, primers_json):
 


### PR DESCRIPTION
This makes two small changes to get the **workflow_main** snakemake workflow working properly.

1. I ran into an issue when running where **samtools** was missing. It is currently being used here https://github.com/vector-engineering/covidcg/blob/093512e62ddca589c454debb18d923e4133ab1d7/workflow_main/Snakefile#L109 but was not included in the `environment.yml` so I added it.
2. In one of the dependency scripts I ran into an issue where it could not find the `read_fasta_file` function so I added an import statement.