### PR TITLE
Converted logo from svg to png

### DIFF
--- a/src/components/LoadingScreen.js
+++ b/src/components/LoadingScreen.js
@@ -14,7 +14,7 @@ import {
   ProgressText,
 } from './LoadingScreen.styles';
 
-import CGLogo from '../assets/images/cg_logo_v13.svg';
+import CGLogo from '../assets/images/cg_logo_v13@4x.png';
 
 const duration = 1000;
 


### PR DESCRIPTION
SVG uses OS font, changing to png standardizes font.