### PR TITLE
Example fix

### DIFF
--- a/src/components/Buttons/QuestionButton.js
+++ b/src/components/Buttons/QuestionButton.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 const QuestionButtonContainer = ({ ...props }) => {
   useEffect(() => {
     // This prevents every single QuestionButton from rebuilding if they aren't visible.
-    if (props.rebuildAfterMount) {
+    if (props.rebuild !== 'false') {
       ReactTooltip.rebuild();
     }
   }, []);

--- a/src/components/Buttons/QuestionButton.js
+++ b/src/components/Buttons/QuestionButton.js
@@ -9,7 +9,7 @@ const QuestionButtonContainer = ({ ...props }) => {
     if (props.rebuildAfterMount) {
       ReactTooltip.rebuild();
     }
-  });
+  }, []);
   return <span {...props}>?</span>;
 };
 
@@ -29,11 +29,11 @@ const QuestionButton = styled(QuestionButtonContainer)`
 `;
 
 QuestionButtonContainer.defaultProps = {
-  rebuild: ''
+  rebuild: 'false',
 };
 
 QuestionButtonContainer.propTypes = {
-  rebuild: PropTypes.bool
+  rebuild: PropTypes.string,
 };
 
 export default QuestionButton;

--- a/src/components/Example/examples.js
+++ b/src/components/Example/examples.js
@@ -44,7 +44,7 @@ export const getExampleItems = ({ selectTree }) => {
           dnaOrAa: DNA_OR_AA.DNA,
           selectedGene: getGene('S'),
           coordinateMode: COORDINATE_MODES.COORD_GENE,
-          selectedLocationNodes: [selectTree], // select root
+          selectedLocationNodes: selectTree.children, // select root
           startDate: MIN_DATE,
           endDate: todayISO(),
         },


### PR DESCRIPTION
Fixes the global lineage example by providing selectTree.children instead of just selectedTree. Also fixes linter issues with QuestionButtonContainer (provides an empty array for useEffect so that it is only called after mount and changes rebuild proptype to string)