### PR TITLE
Domain plot fix

### DIFF
--- a/src/components/Vega/EntropyPlot.js
+++ b/src/components/Vega/EntropyPlot.js
@@ -142,6 +142,8 @@ const EntropyPlot = observer(({ width }) => {
         });
 
         return numRows * heightConst;
+      } else {
+        return heightConst;
       }
     }
 
@@ -246,13 +248,6 @@ const EntropyPlot = observer(({ width }) => {
     return xRange;
   };
 
-  // const checkIfPrimersOverlap = (primer1, primer2) => {
-  //   return (
-  //     (primer1.Start < primer2.End && primer1.End > primer2.End) ||
-  //     (primer1.Start < primer2.Start && primer1.End > primer2.Start)
-  //   );
-  // };
-
   const getDomains = () => {
     // Apply domains
     const xRange = getXRange();
@@ -263,38 +258,6 @@ const EntropyPlot = observer(({ width }) => {
         row: 0,
       },
     ];
-
-    if (configStore.coordinateMode === COORDINATE_MODES.COORD_PRIMER) {
-      if (configStore.selectedPrimers.length > 0) {
-        const selectedPrimers = configStore.selectedPrimers;
-        selectedPrimers[0].row = 0;
-        selectedPrimers.forEach((primerToPlace) => {
-          // let overlaps = true;
-          let curRow = 0;
-          // while (overlaps) {
-          //   const primersInRow = selectedPrimers.filter(
-          //     (primer) => primer.row && primer.row === curRow
-          //   );
-
-          //   for (const primer of primersInRow) {
-          //     overlaps = checkIfPrimersOverlap(primer, primerToPlace);
-          //     if (!overlaps) break;
-          //   }
-
-          //   if (overlaps) curRow += 1;
-          // }
-          primerToPlace.row = curRow;
-          primerToPlace.ranges = [[primerToPlace.Start, primerToPlace.End]];
-          primerToPlace.name = primerToPlace.Name;
-        });
-        configStore.selectedPrimers = selectedPrimers;
-        return selectedPrimers;
-      } else {
-        nullDomain.name = 'No Primers Selected';
-        return nullDomain;
-      }
-    }
-
     if (configStore.residueCoordinates.length === 0) {
       if (configStore.coordinateMode === COORDINATE_MODES.COORD_GENE) {
         return filterMap(geneMap, 'All Genes');
@@ -314,11 +277,73 @@ const EntropyPlot = observer(({ width }) => {
     }
   };
 
+  const checkIfPrimersOverlap = (primer1, primer2) => {
+    return (
+      (primer1.Start < primer2.End && primer1.End > primer2.End) ||
+      (primer1.Start < primer2.Start && primer1.End > primer2.Start)
+    );
+  };
+
+  const getPrimers = () => {
+    const selectedPrimers = configStore.selectedPrimers;
+
+    if (selectedPrimers.length) {
+      selectedPrimers[0].row = 0;
+      for (let i = 0; i < selectedPrimers.length; i++) {
+        let overlaps = true;
+        let curRow = 0;
+        const primerToPlace = selectedPrimers[i];
+
+        while (overlaps) {
+          const primersInRow = selectedPrimers.filter(
+            (primer) => primer.row && primer.row === curRow
+          );
+
+          if (primersInRow.length) {
+            for (const primer of primersInRow) {
+              overlaps = checkIfPrimersOverlap(primer, primerToPlace);
+              if (!overlaps) break;
+            }
+          } else {
+            overlaps = false;
+          }
+
+          if (overlaps) curRow += 1;
+        }
+
+        primerToPlace.row = curRow;
+        primerToPlace.ranges = [[primerToPlace.Start, primerToPlace.End]];
+        primerToPlace.name = primerToPlace.Name;
+        selectedPrimers[i] = primerToPlace;
+      }
+      return selectedPrimers;
+    } else {
+      const nullDomain = [
+        {
+          Institution: 'None',
+          Name: 'No Primers Selected',
+          ranges: [[0, 30000]],
+          row: 0,
+          Start: 0,
+          End: 30000,
+        },
+      ];
+      configStore.selectedPrimers = nullDomain;
+      return nullDomain;
+    }
+  };
+
+  const domainsToShow = () => {
+    return configStore.coordinateMode === COORDINATE_MODES.COORD_PRIMER
+      ? getPrimers()
+      : getDomains();
+  };
+
   const [state, setState] = useState({
     showWarning: true,
     xRange: getXRange(),
     hoverGroup: null,
-    data: { domains: getDomains() },
+    data: { domains: domainsToShow() },
     domainPlotHeight: getDomainPlotHeight(),
     signalListeners: {
       hoverGroup: throttle(handleHoverGroup, 100),
@@ -361,7 +386,7 @@ const EntropyPlot = observer(({ width }) => {
       domainPlotHeight: getDomainPlotHeight(),
       data: {
         ...state.data,
-        domains: getDomains(),
+        domains: domainsToShow(),
         table: processData(),
       },
     });

--- a/src/vega_specs/entropy.vg.json
+++ b/src/vega_specs/entropy.vg.json
@@ -39,10 +39,7 @@
     },
     {
       "name": "xRange",
-      "value": [
-        0,
-        1200
-      ]
+      "value": [0, 1200]
     },
     {
       "name": "xLabel",
@@ -195,15 +192,9 @@
           "type": "lookup",
           "from": "table",
           "key": "mutation",
-          "values": [
-            "color"
-          ],
-          "fields": [
-            "group"
-          ],
-          "as": [
-            "color"
-          ]
+          "values": ["color"],
+          "fields": ["group"],
+          "as": ["color"]
         }
       ]
     },
@@ -563,10 +554,7 @@
         {
           "name": "domainYScale",
           "type": "linear",
-          "domain": [
-            0,
-            5
-          ],
+          "domain": [0, 5],
           "range": {
             "signal": "domainPlotYRange"
           }
@@ -604,6 +592,14 @@
               "x2": {
                 "scale": "xOverview",
                 "field": "end"
+              },
+              "y": {
+                "scale": "domainYScale",
+                "field": "rowTop"
+              },
+              "y2": {
+                "scale": "domainYScale",
+                "field": "rowBottom"
               },
               "tooltip": {
                 "signal": "{ title: datum.name, 'start': datum.start, 'end': datum.end }"
@@ -664,6 +660,13 @@
                 "scale": "xOverview",
                 "field": "datum.start"
               },
+              "yc": {
+                "scale": "domainYScale",
+                "field": "datum.yCenter"
+              },
+              "dy": {
+                "value": 3
+              },
               "tooltip": {
                 "signal": "datum.tooltip"
               },
@@ -683,12 +686,6 @@
           "interactive": false,
           "encode": {
             "enter": {
-              "y": {
-                "value": -5
-              },
-              "height": {
-                "signal": "domainPlotHeight"
-              },
               "fill": {
                 "value": "#333"
               },
@@ -702,6 +699,9 @@
               },
               "x2": {
                 "signal": "brush[1]"
+              },
+              "height": {
+                "signal": "domainPlotHeight"
               }
             }
           }
@@ -711,12 +711,6 @@
           "interactive": false,
           "encode": {
             "enter": {
-              "y": {
-                "value": -5
-              },
-              "height": {
-                "signal": "domainPlotHeight"
-              },
               "width": {
                 "value": 0
               },
@@ -727,6 +721,9 @@
             "update": {
               "x": {
                 "signal": "brush[0]"
+              },
+              "height": {
+                "signal": "domainPlotHeight"
               }
             }
           }
@@ -736,12 +733,6 @@
           "interactive": false,
           "encode": {
             "enter": {
-              "y": {
-                "value": -5
-              },
-              "height": {
-                "signal": "domainPlotHeight"
-              },
               "width": {
                 "value": 0
               },
@@ -752,6 +743,9 @@
             "update": {
               "x": {
                 "signal": "brush[1]"
+              },
+              "height": {
+                "signal": "domainPlotHeight"
               }
             }
           }


### PR DESCRIPTION
The infinite loop in the primer domain plot was caused by a case where primersInRow is empty. A case was added for when primersInRow is empty. In addition, a separate function was made to handle displaying primers in the domain plot rather than having one function for primer and non-primer coordinate modes. This was tested with all primers selected, no primers selected, and random groups of primers selected and worked locally in all cases.

In addition, the vega specs were updated so that the click and drag selection height and domain bar heights update with the plot.