### PR TITLE
More conventional mutation formatting

### DIFF
--- a/services/server/cg_server/query/group_mutation_frequencies.py
+++ b/services/server/cg_server/query/group_mutation_frequencies.py
@@ -18,8 +18,10 @@ def query_group_mutation_frequencies(conn, req):
         table_name = "{group}_frequency_{mutation_type}_mutation".format(
             group=group, mutation_type=mutation_type
         )
-        mutation_table_name = "{mutation_type}_mutation".format(mutation_type=mutation_type)
-        mutation_cols = ["pos", "ref", "alt", "mutation_name"]
+        mutation_table_name = "{mutation_type}_mutation".format(
+            mutation_type=mutation_type
+        )
+        mutation_cols = ["pos", "ref", "alt", "mutation_name", "mutation_str"]
         if mutation_type == "gene_aa":
             mutation_cols = ["gene",] + mutation_cols
         elif mutation_type == "protein_aa":
@@ -55,7 +57,7 @@ def query_group_mutation_frequencies(conn, req):
 
         res = pd.DataFrame.from_records(
             cur.fetchall(),
-            columns=["name", "count", "fraction", "mutation_id",] + mutation_cols,
+            columns=["name", "count", "fraction", "mutation_id"] + mutation_cols,
         )
 
     # print(res)

--- a/src/components/GroupReport/MutationList.js
+++ b/src/components/GroupReport/MutationList.js
@@ -6,8 +6,13 @@ import { format } from 'd3-format';
 
 import { config } from '../../config';
 import { getAllGenes, getAllProteins } from '../../utils/gene_protein';
+import { formatMutation } from '../../utils/mutationUtils';
 import { reds, mutationColorArray } from '../../constants/colors';
-import { ASYNC_STATES, PLOT_DOWNLOAD_OPTIONS } from '../../constants/defs.json';
+import {
+  ASYNC_STATES,
+  PLOT_DOWNLOAD_OPTIONS,
+  DNA_OR_AA,
+} from '../../constants/defs.json';
 
 import GroupSearch from './GroupSearch';
 import EmptyPlot from '../Common/EmptyPlot';
@@ -261,9 +266,8 @@ const MutationListContent = observer(() => {
       // Unique mutations
       .filter(
         (v, i, a) =>
-          a.findIndex(
-            (element) => element.mutation_name === v.mutation_name
-          ) === i
+          a.findIndex((element) => element.mutation_str === v.mutation_str) ===
+          i
       )
       .map((featureMutation) => {
         // Find fractional frequencies for each group
@@ -271,7 +275,7 @@ const MutationListContent = observer(() => {
         groupDataStore.selectedGroups.forEach((group) => {
           const matchingMutation = groupFeatureMutations.find(
             (mut) =>
-              mut.mutation_name === featureMutation.mutation_name &&
+              mut.mutation_str === featureMutation.mutation_str &&
               mut.name === group
           );
           // 0 if the mutation record isn't found
@@ -281,7 +285,13 @@ const MutationListContent = observer(() => {
         });
 
         return {
-          mutation_name: featureMutation.mutation_name,
+          // mutation_name: featureMutation.mutation_name,
+          mutation_name: formatMutation(
+            featureMutation.mutation_str,
+            groupDataStore.groupMutationType === 'dna'
+              ? DNA_OR_AA.DNA
+              : DNA_OR_AA.AA
+          ),
           pos: featureMutation.pos,
           ref: featureMutation.ref,
           alt: featureMutation.alt,
@@ -342,6 +352,7 @@ const MutationListContent = observer(() => {
         groupDataStore.groupMutationType === 'dna'
           ? mut.mutation_name
           : mut.mutation_name.split(':')[1];
+
       rowItems.push(
         <MutationListRow
           key={`group-mut-${feature.name}-${mut.mutation_name}`}

--- a/src/utils/mutationUtils.js
+++ b/src/utils/mutationUtils.js
@@ -8,10 +8,35 @@ export const formatMutation = (mutationStr, dnaOrAa) => {
 
   // Print as REF POS ALT
   // i.e., 23403|A|G -> A23403G, S|614|D|G -> S:D614G
+
   const chunks = mutationStr.split('|');
   if (dnaOrAa === DNA_OR_AA.DNA) {
     return `${chunks[1]}${chunks[0]}${chunks[2]}`;
   } else if (dnaOrAa === DNA_OR_AA.AA) {
-    return `${chunks[0]}:${chunks[2]}${chunks[1]}${chunks[3]}`;
+    let ref = chunks[2];
+    let alt = chunks[3];
+
+    // Translate stop codon from "_" to more conventional "*"
+    if (ref === '_') {
+      ref = '*';
+    }
+    if (alt === '_') {
+      alt = '*';
+    }
+
+    // For deletions, format as ∆[ref][pos]
+    // i.e., F13- --> ∆F13
+    if (alt === '-') {
+      alt = '';
+      ref = '∆' + ref;
+    }
+
+    // For insertions, remove ref '-'
+    // i.e., -13F --> 13F
+    if (ref === '-') {
+      ref = '';
+    }
+
+    return `${chunks[0]}:${ref}${chunks[1]}${alt}`;
   }
 };


### PR DESCRIPTION
- Translate stop codon from "_" to more conventional "*"
- For deletions, format as ∆[ref][pos]. i.e., F13- --> ∆F13
- For insertions, remove ref '-'. i.e., -13F --> 13F

Underlying data downloads remain unchanged (to prevent messing up existing dependent tools)