### PR TITLE
Chunk GenBank (NCBI Virus vvsearch) downloads

### DIFF
--- a/config/config_flu_genbank.yaml
+++ b/config/config_flu_genbank.yaml
@@ -25,6 +25,10 @@ postgres_db: "flu_genbank"
 #       INGEST
 # ------------------
 
+# Download sequences from GenBank (NCBI Virus vvsearch) in chunks of this size
+# D = day, W = week, M = month, Y = year
+dl_chunk_period: "Y"
+
 # Number of genomes to load into memory before flushing to disk
 chunk_size: 10000
 

--- a/config/config_rsv_genbank.yaml
+++ b/config/config_rsv_genbank.yaml
@@ -25,6 +25,10 @@ postgres_db: "rsv_genbank"
 #       INGEST
 # ------------------
 
+# Download sequences from GenBank (NCBI Virus vvsearch) in chunks of this size
+# D = day, W = week, M = month, Y = year
+dl_chunk_period: "Y"
+
 # Number of genomes to load into memory before flushing to disk
 chunk_size: 100000
 

--- a/config/config_sars2_genbank.yaml
+++ b/config/config_sars2_genbank.yaml
@@ -25,7 +25,7 @@ postgres_db: "cg_genbank"
 # ------------------
 
 # Download sequences from GenBank (NCBI Virus vvsearch) in chunks of this size
-# D = day, W = week, M = month
+# D = day, W = week, M = month, Y = year
 dl_chunk_period: "W"
 
 # Number of genomes to load into memory before flushing to disk

--- a/config/config_sars2_genbank.yaml
+++ b/config/config_sars2_genbank.yaml
@@ -24,6 +24,10 @@ postgres_db: "cg_genbank"
 #       INGEST
 # ------------------
 
+# Download sequences from GenBank (NCBI Virus vvsearch) in chunks of this size
+# D = day, W = week, M = month
+dl_chunk_period: "W"
+
 # Number of genomes to load into memory before flushing to disk
 chunk_size: 100000
 

--- a/config/config_sars2_genbank_dev.yaml
+++ b/config/config_sars2_genbank_dev.yaml
@@ -25,6 +25,10 @@ postgres_db: "cg_genbank_dev"
 #       INGEST
 # ------------------
 
+# Download sequences from GenBank (NCBI Virus vvsearch) in chunks of this size
+# D = day, W = week, M = month
+dl_chunk_period: "W"
+
 # Number of genomes to load into memory before flushing to disk
 chunk_size: 100000
 

--- a/config/config_sars2_genbank_dev.yaml
+++ b/config/config_sars2_genbank_dev.yaml
@@ -26,7 +26,7 @@ postgres_db: "cg_genbank_dev"
 # ------------------
 
 # Download sequences from GenBank (NCBI Virus vvsearch) in chunks of this size
-# D = day, W = week, M = month
+# D = day, W = week, M = month, Y = year
 dl_chunk_period: "W"
 
 # Number of genomes to load into memory before flushing to disk

--- a/workflow_flu_genbank_ingest/Snakefile
+++ b/workflow_flu_genbank_ingest/Snakefile
@@ -6,6 +6,8 @@ import gzip
 
 from pathlib import Path
 
+import pandas as pd
+
 configfile: "../config/config_flu_genbank.yaml"
 
 # Get today's date in ISO format (YYYY-MM-DD)
@@ -13,6 +15,12 @@ today_str = datetime.date.today().isoformat()
 
 data_folder = os.path.join("..", config["data_folder"])
 static_data_folder = os.path.join("..", config["static_data_folder"])
+
+min_date = pd.to_datetime(config.get('min_date', '2019-12-01'))
+max_date = pd.to_datetime(datetime.date.today().isoformat())
+
+chunks = [d for d in pd.period_range(start=min_date, end=max_date, freq=config.get('dl_chunk_period', 'W'))]
+DL_CHUNKS = [i for i in range(len(chunks))]
 
 rule all:
     input:
@@ -31,18 +39,37 @@ rule all:
         os.path.join(data_folder, 'metadata_virus+serotype.csv')
 
 
-rule download:
-    """Download latest data from GenBank. The feed "JSON" is actually a file of
-    newline-delimited JSON records (the file itself is not strict JSON)
+rule download_chunk:
+    """Download the data feed in chunks, to avoid timeouts.
     """
     output:
-        feed = os.path.join(data_folder, "feed.csv"),
+        feed = os.path.join(data_folder, 'feed_chunks', 'feed_{chunk}.csv'),
+    params:
+        start_time = lambda wildcards: chunks[int(wildcards.chunk)].start_time.strftime('%Y-%m-%dT%H:%M:%S.00Z'),
+        end_time = lambda wildcards: chunks[int(wildcards.chunk)].end_time.strftime('%Y-%m-%dT%H:%M:%S.00Z')
+    shell:
+        """
+        python3 scripts/download.py \
+            --start-time {params.start_time} --end-time {params.end_time} \
+                > {output.feed}
+        """
+
+rule combine_download_chunks:
+    """Combine all the downloaded chunks into a single CSV file.
+    Combining CSV files without duplicating header: https://apple.stackexchange.com/a/348619
+    """
+    input:
+        chunks = expand(os.path.join(data_folder, 'feed_chunks', 'feed_{chunk}.csv'), chunk=DL_CHUNKS)
+    params:
+        chunk_glob = os.path.join(data_folder, 'feed_chunks', 'feed*.csv')
+    output:
+        feed = os.path.join(data_folder, 'feed.csv'),
         status = touch(os.path.join(
             data_folder, "status", "download_" + today_str + ".done"
         ))
     shell:
         """
-        python3 scripts/download.py > {output.feed}
+        awk '(NR == 1) || (FNR > 1)' {params.chunk_glob} > {output.feed}
         """
 
 
@@ -50,7 +77,7 @@ rule clean_metadata:
     """Clean metadata, incorporate lineage assignments into metadata
     """
     input:
-        metadata_dirty = rules.download.output.feed
+        metadata_dirty = rules.combine_download_chunks.output.feed
     output:
         metadata_clean = os.path.join(data_folder, "metadata.csv"),
         metadata_virus = os.path.join(data_folder, "metadata_virus.csv")
@@ -65,7 +92,7 @@ rule clean_metadata:
 
 rule write_ha_fasta:
     input:
-        feed = rules.download.output.feed,
+        feed = rules.combine_download_chunks.output.feed,
         metadata = rules.clean_metadata.output.metadata_clean
     output:
         sequences = os.path.join(data_folder, 'ha.fa.gz')
@@ -116,7 +143,7 @@ checkpoint chunk_sequences:
     We end up with hundreds of files, but the filesystem seems to be handling it well.
     """
     input:
-        feed = rules.download.output.feed,
+        feed = rules.combine_download_chunks.output.feed,
         metadata = rules.clean_metadata.output.metadata_clean,
         metadata_virus = rules.join_serotype_assignments.output.metadata_virus_plus_serotype,
     output:

--- a/workflow_rsv_genbank_ingest/Snakefile
+++ b/workflow_rsv_genbank_ingest/Snakefile
@@ -6,6 +6,8 @@ import gzip
 
 from pathlib import Path
 
+import pandas as pd
+
 configfile: "../config/config_rsv_genbank.yaml"
 
 # Get today's date in ISO format (YYYY-MM-DD)
@@ -13,6 +15,12 @@ today_str = datetime.date.today().isoformat()
 
 data_folder = os.path.join("..", config["data_folder"])
 static_data_folder = os.path.join("..", config["static_data_folder"])
+
+min_date = pd.to_datetime(config.get('min_date', '2019-12-01'))
+max_date = pd.to_datetime(datetime.date.today().isoformat())
+
+chunks = [d for d in pd.period_range(start=min_date, end=max_date, freq=config.get('dl_chunk_period', 'W'))]
+DL_CHUNKS = [i for i in range(len(chunks))]
 
 rule all:
     input:
@@ -33,25 +41,44 @@ rule all:
         seq_by_subtype_tar = os.path.join(data_folder, 'seq_by_subtype.tar.gz')
 
 
-rule download:
-    """Download latest data from GenBank. The feed "JSON" is actually a file of
-    newline-delimited JSON records (the file itself is not strict JSON)
+rule download_chunk:
+    """Download the data feed in chunks, to avoid timeouts.
     """
     output:
-        feed = os.path.join(data_folder, "feed.csv"),
+        feed = os.path.join(data_folder, 'feed_chunks', 'feed_{chunk}.csv'),
+    params:
+        start_time = lambda wildcards: chunks[int(wildcards.chunk)].start_time.strftime('%Y-%m-%dT%H:%M:%S.00Z'),
+        end_time = lambda wildcards: chunks[int(wildcards.chunk)].end_time.strftime('%Y-%m-%dT%H:%M:%S.00Z')
+    shell:
+        """
+        python3 scripts/download.py \
+            --start-time {params.start_time} --end-time {params.end_time} \
+                > {output.feed}
+        """
+
+rule combine_download_chunks:
+    """Combine all the downloaded chunks into a single CSV file.
+    Combining CSV files without duplicating header: https://apple.stackexchange.com/a/348619
+    """
+    input:
+        chunks = expand(os.path.join(data_folder, 'feed_chunks', 'feed_{chunk}.csv'), chunk=DL_CHUNKS)
+    params:
+        chunk_glob = os.path.join(data_folder, 'feed_chunks', 'feed*.csv')
+    output:
+        feed = os.path.join(data_folder, 'feed.csv'),
         status = touch(os.path.join(
             data_folder, "status", "download_" + today_str + ".done"
         ))
     shell:
         """
-        python3 scripts/download.py > {output.feed}
+        awk '(NR == 1) || (FNR > 1)' {params.chunk_glob} > {output.feed}
         """
 
 rule clean_metadata:
     """Clean metadata
     """
     input:
-        metadata_dirty = rules.download.output.feed,
+        metadata_dirty = rules.combine_download_chunks.output.feed,
     output:
         metadata_clean = os.path.join(data_folder, "metadata_no_subtype.csv")
     shell:
@@ -63,8 +90,8 @@ rule clean_metadata:
 
 rule write_all_fasta:
     input:
-        feed = rules.download.output.feed,
-        download_status = rules.download.output.status, # Force this step every day
+        feed = rules.combine_download_chunks.output.feed,
+        download_status = rules.combine_download_chunks.output.status, # Force this step every day
         metadata = rules.clean_metadata.output.metadata_clean
     output:
         sequences = os.path.join(data_folder, 'all_sequences.fa.gz')
@@ -114,7 +141,7 @@ rule split_sequences_by_subtype:
     """Split sequences by subtype
     """
     input:
-        feed = rules.download.output.feed,
+        feed = rules.combine_download_chunks.output.feed,
         metadata = rules.join_subtype_assignments.output.metadata_plus_subtype
     output:
         seq_A = os.path.join(data_folder, 'seq_by_subtype', 'sequences_A.fa.gz'),
@@ -148,7 +175,7 @@ checkpoint chunk_sequences:
     hundreds of files, but the filesystem seems to be handling it well.
     """
     input:
-        feed = rules.download.output.feed,
+        feed = rules.combine_download_chunks.output.feed,
         metadata = rules.join_subtype_assignments.output.metadata_plus_subtype,
     output:
         fasta = directory(os.path.join(data_folder, "fasta_temp"))

--- a/workflow_rsv_genbank_ingest/scripts/download.py
+++ b/workflow_rsv_genbank_ingest/scripts/download.py
@@ -23,64 +23,89 @@ by comparing different download requests and guessing, which allows us to
 download the metadata + sequence in the same request instead of two.
 """
 
+
+import argparse
 import requests
 
-endpoint = "https://www.ncbi.nlm.nih.gov/genomes/VirusVariation/vvsearch2/"
-params = {
-    # Search criteria
-    "fq": [
-        '{!tag=SeqType_s}SeqType_s:("Nucleotide")',  # Nucleotide sequences (as opposed to protein)
-        "VirusLineageId_ss:(11250)",  # NCBI Taxon id for RSV
-    ],
-    # Unclear, but seems necessary.
-    "q": "*:*",
-    # Response format
-    "cmd": "download",
-    "dlfmt": "csv",
-    "fl": ",".join(
-        ":".join(names)
-        for names in [
-            # Pairs of (output column name, source data field).  These are pulled
-            # from watching requests from the UI.
-            #
-            # XXX TODO: Is the full set source data fields documented
-            # somewhere?  Is there more info we could be pulling that'd be
-            # useful?
-            #   -trs, 13 May 2020
-            ("genbank_accession", "id"),
-            ("database", "SourceDB_s"),
-            ("strain", "Isolate_s"),
-            ("region", "Region_s"),
-            ("location", "CountryFull_s"),
-            ("collected", "CollectionDate_s"),
-            ("submitted", "CreateDate_dt"),
-            ("length", "SLen_i"),
-            ("host", "Host_s"),
-            ("isolation_source", "Isolation_csv"),
-            ("biosample_accession", "BioSample_s"),
-            ("title", "Definition_s"),
-            ("authors", "Authors_csv"),
-            ("publications", "PubMed_csv"),
-            ("sequence", "Nucleotide_seq"),
-            ("protein_names", "ProtNames_ss")
-        ]
-    ),
-    # Stable sort with newest last so diffs work nicely.  Columns are source
-    # data fields, not our output columns.
-    "sort": "SourceDB_s desc, CollectionDate_s asc, id asc",
-    # This isn't Entrez, but include the same email parameter it requires just
-    # to be nice.
-    "email": "covidcg@broadinstitute.org",
-}
 
-headers = {
-    "User-Agent": "https://github.com/vector-engineering/covid-cg (covidcg@broadinstitute.org)",
-}
+def main():
 
-response = requests.get(endpoint, params=params, headers=headers, stream=True)
-response.raise_for_status()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--start-time",
+        type=str,
+        required=True,
+        help="Start time in format YYYY-MM-DDTHH:MM:SS.00Z",
+    )
+    parser.add_argument(
+        "--end-time",
+        type=str,
+        required=True,
+        help="Start time in format YYYY-MM-DDTHH:MM:SS.00Z",
+    )
+    args = parser.parse_args()
 
-response_content = response.iter_content(chunk_size=1024, decode_unicode=True)
+    endpoint = "https://www.ncbi.nlm.nih.gov/genomes/VirusVariation/vvsearch2/"
+    params = {
+        # Search criteria
+        "fq": [
+            '{!tag=SeqType_s}SeqType_s:("Nucleotide")',  # Nucleotide sequences (as opposed to protein)
+            "VirusLineageId_ss:(11250)",  # NCBI Taxon id for RSV
+            f"{{!tag=CreateDate_dt}}CreateDate_dt:([{args.start_time} TO {args.end_time}])",
+        ],
+        # Unclear, but seems necessary.
+        "q": "*:*",
+        # Response format
+        "cmd": "download",
+        "dlfmt": "csv",
+        "fl": ",".join(
+            ":".join(names)
+            for names in [
+                # Pairs of (output column name, source data field).  These are pulled
+                # from watching requests from the UI.
+                #
+                # XXX TODO: Is the full set source data fields documented
+                # somewhere?  Is there more info we could be pulling that'd be
+                # useful?
+                #   -trs, 13 May 2020
+                ("genbank_accession", "id"),
+                ("database", "SourceDB_s"),
+                ("strain", "Isolate_s"),
+                ("region", "Region_s"),
+                ("location", "CountryFull_s"),
+                ("collected", "CollectionDate_s"),
+                ("submitted", "CreateDate_dt"),
+                ("length", "SLen_i"),
+                ("host", "Host_s"),
+                ("isolation_source", "Isolation_csv"),
+                ("biosample_accession", "BioSample_s"),
+                ("title", "Definition_s"),
+                ("authors", "Authors_csv"),
+                ("publications", "PubMed_csv"),
+                ("sequence", "Nucleotide_seq"),
+                ("protein_names", "ProtNames_ss"),
+            ]
+        ),
+        # Stable sort with newest last so diffs work nicely.  Columns are source
+        # data fields, not our output columns.
+        "sort": "SourceDB_s desc, CollectionDate_s asc, id asc",
+        # This isn't Entrez, but include the same email parameter it requires just
+        # to be nice.
+        "email": "covidcg@broadinstitute.org",
+    }
 
-for chunk in response_content:
-    print(chunk, end="")
+    headers = {
+        "User-Agent": "https://github.com/vector-engineering/covid-cg (covidcg@broadinstitute.org)",
+    }
+
+    response = requests.get(endpoint, params=params, headers=headers, stream=True)
+    response.raise_for_status()
+
+    response_content = response.iter_content(chunk_size=1024, decode_unicode=True)
+
+    for chunk in response_content:
+        print(chunk, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/workflow_sars2_genbank_ingest/Snakefile
+++ b/workflow_sars2_genbank_ingest/Snakefile
@@ -6,6 +6,8 @@ import gzip
 
 from pathlib import Path
 
+import pandas as pd
+
 # Import scripts
 from scripts.chunk_data import chunk_data
 from scripts.clean_metadata import clean_metadata
@@ -31,28 +33,57 @@ rule all:
         # Cleaned metadata, with lineage assignments
         os.path.join(data_folder, "metadata.csv")
 
+min_date = pd.to_datetime(config.get('min_date', '2019-12-01'))
+max_date = pd.to_datetime(datetime.date.today().isoformat())
 
-rule download:
-    """Download latest data from GenBank. The feed "JSON" is actually a file of
-    newline-delimited JSON records (the file itself is not strict JSON)
+chunks = [d for d in pd.period_range(start=min_date, end=max_date, freq='W')]
+DL_CHUNKS = [i for i in range(len(chunks))]
+
+rule download_chunk:
+    """Download the data feed in chunks, to avoid timeouts.
     """
     output:
-        feed = temp(os.path.join(data_folder, "feed.csv")),
+        feed = os.path.join(data_folder, 'feed_chunks', 'feed_{chunk}.csv'),
+    params:
+        start_time = lambda wildcards: chunks[int(wildcards.chunk)].start_time.strftime('%Y-%m-%dT%H:%M:%S.00Z'),
+        end_time = lambda wildcards: chunks[int(wildcards.chunk)].end_time.strftime('%Y-%m-%dT%H:%M:%S.00Z')
+    shell:
+        """
+        python3 scripts/download.py \
+            --start-time {params.start_time} --end-time {params.end_time} \
+                > {output.feed}
+        """
+
+rule combine_download_chunks:
+    """Combine all the downloaded chunks into a single CSV file.
+    Combining CSV files without duplicating header: https://apple.stackexchange.com/a/348619
+    """
+    input:
+        chunks = expand(os.path.join(data_folder, 'feed_chunks', 'feed_{chunk}.csv'), chunk=DL_CHUNKS)
+    params:
+        chunk_glob = os.path.join(data_folder, 'feed_chunks', 'feed*.csv')
+    output:
+        feed = os.path.join(data_folder, 'feed.csv'),
         status = touch(os.path.join(
             data_folder, "status", "download_" + today_str + ".done"
         ))
     shell:
         """
-        python3 scripts/download.py > {output.feed}
+        awk '(NR == 1) || (FNR > 1)' {params.chunk_glob} > {output.feed}
         """
 
 
 checkpoint chunk_data:
-    """Split up the data feed's individual JSON objects into metadata and fasta files. Chunk the fasta files so that every day we only reprocess the subset of fasta files that have changed. The smaller the chunk size, the more efficient the updates, but the more files on the filesystem.
-    On a 48-core workstation with 128 GB RAM, aligning 200 sequences takes about 10 minutes, and this is more acceptable than having to align 1000 sequences, which takes ~1 hour. We end up with hundreds of files, but the filesystem seems to be handling it well.
+    """Split up the data feed's individual JSON objects into metadata and fasta files. 
+    Chunk the fasta files so that every day we only reprocess the subset of fasta files that 
+    have changed. The smaller the chunk size, the more efficient the updates, but the more 
+    files on the filesystem.
+    On a 48-core workstation with 128 GB RAM, aligning 200 sequences takes about 10 minutes, 
+    and this is more acceptable than having to align 1000 sequences, which takes ~1 hour. 
+    We end up with hundreds of files, but the filesystem seems to be handling it well.
     """
     input:
-        feed = rules.download.output.feed
+        feed = rules.combine_download_chunks.output.feed
     output:
         fasta = directory(os.path.join(data_folder, "fasta_temp")),
         metadata_dirty = os.path.join(data_folder, "metadata_dirty.csv")
@@ -80,8 +111,9 @@ def get_num_seqs(fasta_gz):
 
 def get_changed_chunks(wildcards):
     """Helper function for detecting which chunks have changed in terms of their contents
-    (measured in equality by bytes of disk space occupied). Only re-process and re-align chunks which have changed. This will save us a ton of computational time, as now that there are 200K+
-    isolates on GISAID, aligning them would take 1 week for the whole batch.
+    (measured in equality by bytes of disk space occupied). Only re-process and re-align 
+    chunks which have changed. This will save us a ton of computational time, as now that 
+    there are 200K+ isolates on GISAID, aligning them would take 1 week for the whole batch.
     """
 
     # Only run to trigger DAG re-evaluation

--- a/workflow_sars2_genbank_ingest/Snakefile
+++ b/workflow_sars2_genbank_ingest/Snakefile
@@ -36,7 +36,7 @@ rule all:
 min_date = pd.to_datetime(config.get('min_date', '2019-12-01'))
 max_date = pd.to_datetime(datetime.date.today().isoformat())
 
-chunks = [d for d in pd.period_range(start=min_date, end=max_date, freq='W')]
+chunks = [d for d in pd.period_range(start=min_date, end=max_date, freq=config.get('dl_chunk_period', 'W'))]
 DL_CHUNKS = [i for i in range(len(chunks))]
 
 rule download_chunk:

--- a/workflow_sars2_genbank_ingest/scripts/download.py
+++ b/workflow_sars2_genbank_ingest/scripts/download.py
@@ -23,63 +23,87 @@ by comparing different download requests and guessing, which allows us to
 download the metadata + sequence in the same request instead of two.
 """
 
+import argparse
 import requests
 
-endpoint = "https://www.ncbi.nlm.nih.gov/genomes/VirusVariation/vvsearch2/"
-params = {
-    # Search criteria
-    "fq": [
-        '{!tag=SeqType_s}SeqType_s:("Nucleotide")',  # Nucleotide sequences (as opposed to protein)
-        "VirusLineageId_ss:(2697049)",  # NCBI Taxon id for SARS-CoV-2
-    ],
-    # Unclear, but seems necessary.
-    "q": "*:*",
-    # Response format
-    "cmd": "download",
-    "dlfmt": "csv",
-    "fl": ",".join(
-        ":".join(names)
-        for names in [
-            # Pairs of (output column name, source data field).  These are pulled
-            # from watching requests from the UI.
-            #
-            # XXX TODO: Is the full set source data fields documented
-            # somewhere?  Is there more info we could be pulling that'd be
-            # useful?
-            #   -trs, 13 May 2020
-            ("genbank_accession", "id"),
-            ("database", "SourceDB_s"),
-            ("strain", "Isolate_s"),
-            ("region", "Region_s"),
-            ("location", "CountryFull_s"),
-            ("collected", "CollectionDate_s"),
-            ("submitted", "CreateDate_dt"),
-            ("length", "SLen_i"),
-            ("host", "Host_s"),
-            ("isolation_source", "Isolation_csv"),
-            ("biosample_accession", "BioSample_s"),
-            ("title", "Definition_s"),
-            ("authors", "Authors_csv"),
-            ("publications", "PubMed_csv"),
-            ("sequence", "Nucleotide_seq"),
-        ]
-    ),
-    # Stable sort with newest last so diffs work nicely.  Columns are source
-    # data fields, not our output columns.
-    "sort": "SourceDB_s desc, CollectionDate_s asc, id asc",
-    # This isn't Entrez, but include the same email parameter it requires just
-    # to be nice.
-    "email": "covidcg@broadinstitute.org",
-}
 
-headers = {
-    "User-Agent": "https://github.com/vector-engineering/covid-cg (covidcg@broadinstitute.org)",
-}
+def main():
 
-response = requests.get(endpoint, params=params, headers=headers, stream=True)
-response.raise_for_status()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--start-time",
+        type=str,
+        required=True,
+        help="Start time in format YYYY-MM-DDTHH:MM:SS.00Z",
+    )
+    parser.add_argument(
+        "--end-time",
+        type=str,
+        required=True,
+        help="Start time in format YYYY-MM-DDTHH:MM:SS.00Z",
+    )
+    args = parser.parse_args()
 
-response_content = response.iter_content(chunk_size=1024, decode_unicode=True)
+    endpoint = "https://www.ncbi.nlm.nih.gov/genomes/VirusVariation/vvsearch2/"
+    params = {
+        # Search criteria
+        "fq": [
+            '{!tag=SeqType_s}SeqType_s:("Nucleotide")',  # Nucleotide sequences (as opposed to protein)
+            "VirusLineageId_ss:(2697049)",  # NCBI Taxon id for SARS-CoV-2
+            f"{{!tag=CreateDate_dt}}CreateDate_dt:([{args.start_time} TO {args.end_time}])",
+        ],
+        # Unclear, but seems necessary.
+        "q": "*:*",
+        # Response format
+        "cmd": "download",
+        "dlfmt": "csv",
+        "fl": ",".join(
+            ":".join(names)
+            for names in [
+                # Pairs of (output column name, source data field).  These are pulled
+                # from watching requests from the UI.
+                #
+                # XXX TODO: Is the full set source data fields documented
+                # somewhere?  Is there more info we could be pulling that'd be
+                # useful?
+                #   -trs, 13 May 2020
+                ("genbank_accession", "id"),
+                ("database", "SourceDB_s"),
+                ("strain", "Isolate_s"),
+                ("region", "Region_s"),
+                ("location", "CountryFull_s"),
+                ("collected", "CollectionDate_s"),
+                ("submitted", "CreateDate_dt"),
+                ("length", "SLen_i"),
+                ("host", "Host_s"),
+                ("isolation_source", "Isolation_csv"),
+                ("biosample_accession", "BioSample_s"),
+                ("title", "Definition_s"),
+                ("authors", "Authors_csv"),
+                ("publications", "PubMed_csv"),
+                ("sequence", "Nucleotide_seq"),
+            ]
+        ),
+        # Stable sort with newest last so diffs work nicely.  Columns are source
+        # data fields, not our output columns.
+        "sort": "SourceDB_s desc, CollectionDate_s asc, id asc",
+        # This isn't Entrez, but include the same email parameter it requires just
+        # to be nice.
+        "email": "covidcg@broadinstitute.org",
+    }
 
-for chunk in response_content:
-    print(chunk, end="")
+    headers = {
+        "User-Agent": "https://github.com/vector-engineering/covid-cg (covidcg@broadinstitute.org)",
+    }
+
+    response = requests.get(endpoint, params=params, headers=headers, stream=True)
+    response.raise_for_status()
+
+    response_content = response.iter_content(chunk_size=1024, decode_unicode=True)
+
+    for chunk in response_content:
+        print(chunk, end="")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Current downloads for SARS2 on the NCBI Virus endpoint are timing out due to large data size. This PR chunks out downloads by a user-configurable period and combines chunks to feed into existing ingest workflows.