### PR TITLE
Uncompress SARS2 feed file on the fly to save disk space

### DIFF
--- a/workflow_sars2_gisaid_ingest/Snakefile
+++ b/workflow_sars2_gisaid_ingest/Snakefile
@@ -34,14 +34,12 @@ rule all:
 
 
 rule download:
-    """Download the data feed JSON object from the GISAID database, using our data feed credentials. The resulting file will need to be decompressed by `decompress_data_feed`
-    """
+    """Download the data feed JSON object from the GISAID database, using our data feed credentials."""
     output:
-        feed = temp(os.path.join(data_folder, "feed.json")),
+        feed = temp(os.path.join(data_folder, "feed.json.xz")),
         status = touch(rules.all.input.download_status)
-    threads: workflow.cores
     shell:
-        "scripts/download.sh | unxz --threads={threads} -c - > {output.feed}"
+        "scripts/download.sh > {output.feed}"
 
 
 rule process_feed:

--- a/workflow_sars2_gisaid_ingest/scripts/process_feed.py
+++ b/workflow_sars2_gisaid_ingest/scripts/process_feed.py
@@ -173,7 +173,7 @@ def main():
 
     # Get fields for each isolate
     fields = []
-    with lzma.open(args.data_feed, "rt") as fp_in:
+    with lzma.open(args.data_feed, "xt") as fp_in:
         isolate = json.loads(fp_in.readline().strip())
         for i, key in enumerate(isolate.keys()):
             # Skip the special sequence column

--- a/workflow_sars2_gisaid_ingest/scripts/process_feed.py
+++ b/workflow_sars2_gisaid_ingest/scripts/process_feed.py
@@ -14,6 +14,7 @@ import datetime
 import gzip
 import hashlib
 import json
+import lzma
 import multiprocessing as mp
 import os
 import pandas as pd
@@ -172,7 +173,7 @@ def main():
 
     # Get fields for each isolate
     fields = []
-    with open(args.data_feed, "r") as fp_in:
+    with lzma.open(args.data_feed, "rt") as fp_in:
         isolate = json.loads(fp_in.readline().strip())
         for i, key in enumerate(isolate.keys()):
             # Skip the special sequence column


### PR DESCRIPTION
Decompress the feed.json.xz file as a stream in `process_feed.py` instead of storing the plaintext JSON on disk -- it was exceeding hundreds of GB