### PR TITLE
Truncated main workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,8 @@ data_flu/**
 data_gisaid_flu/**
 data_gisaid_rsv/**
 data_genbank_rsv/**
+data_6month
+data_6month/**
 
 # Ignore server passwords
 server/htpasswd
@@ -108,7 +110,8 @@ daily_update.sh
 daily_update_new.sh
 daily_update_rsv.sh
 daily_update_sars2_genbank.sh
-daily_update_sars2_gisaid.sh
+daily_update_sars2_gisaid_full.sh
+daily_update_sars2_gisaid_6month.sh
 update_gisaid.sh
 update_genbank.sh
 filter_list.txt

--- a/config/config_flu_genbank.yaml
+++ b/config/config_flu_genbank.yaml
@@ -36,6 +36,20 @@ chunk_size: 10000
 #       ANALYSIS
 # --------------------
 
+# Don't process sequences prior to this date
+# Leave empty to ignore
+start_date_cutoff:
+# Don't process sequences after this date
+# Leave empty to ignore
+end_date_cutoff:
+
+# Don't process sequences after X days ago
+# Leave empty to ignore
+start_date_cutoff_days_ago:
+# Don't process sequences prior to X days ago
+# Leave empty to ignore
+end_date_cutoff_days_ago:
+
 segments: ["1", "2", "3", "4", "5", "6", "7", "8"]
 
 # Insertions or deletions with more than this difference in bases between the

--- a/config/config_flu_gisaid.yaml
+++ b/config/config_flu_gisaid.yaml
@@ -32,6 +32,20 @@ chunk_size: 10000
 #       ANALYSIS
 # --------------------
 
+# Don't process sequences prior to this date
+# Leave empty to ignore
+start_date_cutoff:
+# Don't process sequences after this date
+# Leave empty to ignore
+end_date_cutoff:
+
+# Don't process sequences after X days ago
+# Leave empty to ignore
+start_date_cutoff_days_ago:
+# Don't process sequences prior to X days ago
+# Leave empty to ignore
+end_date_cutoff_days_ago:
+
 segments: ["1", "2", "3", "4", "5", "6", "7", "8"]
 
 # Insertions or deletions with more than this difference in bases between the

--- a/config/config_flu_gisaid_dev.yaml
+++ b/config/config_flu_gisaid_dev.yaml
@@ -32,6 +32,20 @@ chunk_size: 10000
 #       ANALYSIS
 # --------------------
 
+# Don't process sequences prior to this date
+# Leave empty to ignore
+start_date_cutoff:
+# Don't process sequences after this date
+# Leave empty to ignore
+end_date_cutoff:
+
+# Don't process sequences after X days ago
+# Leave empty to ignore
+start_date_cutoff_days_ago:
+# Don't process sequences prior to X days ago
+# Leave empty to ignore
+end_date_cutoff_days_ago:
+
 segments: ["1", "2", "3", "4", "5", "6", "7", "8"]
 
 # Insertions or deletions with more than this difference in bases between the

--- a/config/config_rsv_custom.yaml
+++ b/config/config_rsv_custom.yaml
@@ -31,6 +31,20 @@ chunk_size: 100000
 #       ANALYSIS
 # --------------------
 
+# Don't process sequences prior to this date
+# Leave empty to ignore
+start_date_cutoff:
+# Don't process sequences after this date
+# Leave empty to ignore
+end_date_cutoff:
+
+# Don't process sequences after X days ago
+# Leave empty to ignore
+start_date_cutoff_days_ago:
+# Don't process sequences prior to X days ago
+# Leave empty to ignore
+end_date_cutoff_days_ago:
+
 segments: ["1"]
 
 # Insertions or deletions with more than this difference in bases between the

--- a/config/config_rsv_genbank.yaml
+++ b/config/config_rsv_genbank.yaml
@@ -36,6 +36,20 @@ chunk_size: 100000
 #       ANALYSIS
 # --------------------
 
+# Don't process sequences prior to this date
+# Leave empty to ignore
+start_date_cutoff:
+# Don't process sequences after this date
+# Leave empty to ignore
+end_date_cutoff:
+
+# Don't process sequences after X days ago
+# Leave empty to ignore
+start_date_cutoff_days_ago:
+# Don't process sequences prior to X days ago
+# Leave empty to ignore
+end_date_cutoff_days_ago:
+
 segments: ["1"]
 
 # Insertions or deletions with more than this difference in bases between the

--- a/config/config_sars2_alpha.yaml
+++ b/config/config_sars2_alpha.yaml
@@ -31,6 +31,20 @@ chunk_size: 100000
 #       ANALYSIS
 # --------------------
 
+# Don't process sequences prior to this date
+# Leave empty to ignore
+start_date_cutoff:
+# Don't process sequences after this date
+# Leave empty to ignore
+end_date_cutoff:
+
+# Don't process sequences after X days ago
+# Leave empty to ignore
+start_date_cutoff_days_ago:
+# Don't process sequences prior to X days ago
+# Leave empty to ignore
+end_date_cutoff_days_ago:
+
 segments: ["1"]
 
 # Insertions or deletions with more than this difference in bases between the

--- a/config/config_sars2_custom.yaml
+++ b/config/config_sars2_custom.yaml
@@ -31,6 +31,20 @@ chunk_size: 100000
 #       ANALYSIS
 # --------------------
 
+# Don't process sequences prior to this date
+# Leave empty to ignore
+start_date_cutoff:
+# Don't process sequences after this date
+# Leave empty to ignore
+end_date_cutoff:
+
+# Don't process sequences after X days ago
+# Leave empty to ignore
+start_date_cutoff_days_ago:
+# Don't process sequences prior to X days ago
+# Leave empty to ignore
+end_date_cutoff_days_ago:
+
 segments: ["1"]
 
 # Insertions or deletions with more than this difference in bases between the

--- a/config/config_sars2_genbank.yaml
+++ b/config/config_sars2_genbank.yaml
@@ -35,6 +35,20 @@ chunk_size: 100000
 #       ANALYSIS
 # --------------------
 
+# Don't process sequences prior to this date
+# Leave empty to ignore
+start_date_cutoff:
+# Don't process sequences after this date
+# Leave empty to ignore
+end_date_cutoff:
+
+# Don't process sequences after X days ago
+# Leave empty to ignore
+start_date_cutoff_days_ago:
+# Don't process sequences prior to X days ago
+# Leave empty to ignore
+end_date_cutoff_days_ago:
+
 segments: ["1"]
 
 # Insertions or deletions with more than this difference in bases between the

--- a/config/config_sars2_genbank_dev.yaml
+++ b/config/config_sars2_genbank_dev.yaml
@@ -36,6 +36,20 @@ chunk_size: 100000
 #       ANALYSIS
 # --------------------
 
+# Don't process sequences prior to this date
+# Leave empty to ignore
+start_date_cutoff:
+# Don't process sequences after this date
+# Leave empty to ignore
+end_date_cutoff:
+
+# Don't process sequences after X days ago
+# Leave empty to ignore
+start_date_cutoff_days_ago:
+# Don't process sequences prior to X days ago
+# Leave empty to ignore
+end_date_cutoff_days_ago:
+
 segments: ["1"]
 
 # Insertions or deletions with more than this difference in bases between the

--- a/config/config_sars2_gisaid_6month.yaml
+++ b/config/config_sars2_gisaid_6month.yaml
@@ -7,7 +7,7 @@ virus: "sars2"
 
 # Path to folder with downloaded and processed data
 # This path is relative to the project root
-data_folder: "data"
+data_folder: "data_6month"
 
 # Path to folder with genome information (reference.fasta, genes.json, proteins.json)
 # This path is relative to the project root
@@ -18,7 +18,7 @@ static_data_folder: "static_data/sars2"
 example_data_folder: "data"
 
 # Database for this virus
-postgres_db: "cg_gisaid"
+postgres_db: "cg_gisaid_6month"
 
 # ------------------
 #       INGEST
@@ -40,7 +40,7 @@ end_date_cutoff:
 
 # Don't process sequences after X days ago
 # Leave empty to ignore
-start_date_cutoff_days_ago:
+start_date_cutoff_days_ago: 180
 # Don't process sequences prior to X days ago
 # Leave empty to ignore
 end_date_cutoff_days_ago:

--- a/config/config_sars2_gisaid_private.yaml
+++ b/config/config_sars2_gisaid_private.yaml
@@ -31,6 +31,20 @@ chunk_size: 100000
 #       ANALYSIS
 # --------------------
 
+# Don't process sequences prior to this date
+# Leave empty to ignore
+start_date_cutoff:
+# Don't process sequences after this date
+# Leave empty to ignore
+end_date_cutoff:
+
+# Don't process sequences after X days ago
+# Leave empty to ignore
+start_date_cutoff_days_ago:
+# Don't process sequences prior to X days ago
+# Leave empty to ignore
+end_date_cutoff_days_ago:
+
 segments: ["1"]
 
 # Insertions or deletions with more than this difference in bases between the

--- a/services/server/cg_server/db_seed/seed.py
+++ b/services/server/cg_server/db_seed/seed.py
@@ -298,6 +298,12 @@ def seed_database(conn, schema="public"):
         isolate_df["collection_date"] = pd.to_datetime(isolate_df["collection_date"])
         isolate_df["submission_date"] = pd.to_datetime(isolate_df["submission_date"])
         # print(isolate_df.columns)
+        if 'gisaid_lineage' in isolate_df.columns:
+            isolate_df['gisaid_lineage'] = isolate_df['gisaid_lineage'].fillna('Unassigned')
+        if 'lineage' in isolate_df.columns:
+            isolate_df['lineage'] = isolate_df['lineage'].fillna('Unassigned')
+        if 'clade' in isolate_df.columns:
+            isolate_df['clade'] = isolate_df['clade'].fillna('Unassigned')
 
         # Make a column for each metadata field
         metadata_cols = []

--- a/workflow_main/Snakefile
+++ b/workflow_main/Snakefile
@@ -3,6 +3,7 @@
 """Main data processing workflow from ingested data
 
 $ snakemake --configfile ../config/config_sars2_gisaid.yaml -j6
+$ snakemake --configfile ../config/config_sars2_gisaid_6month.yaml -j6 -R sequence_manifest
 $ snakemake --configfile ../config/config_sars2_genbank_dev.yaml -j6
 $ snakemake --configfile ../config/config_rsv_genbank.yaml -j6
 $ snakemake --configfile ../config/config_flu_genbank.yaml -j6
@@ -35,6 +36,8 @@ import datetime
 import os
 from pathlib import Path
 
+import pandas as pd
+
 data_folder = os.path.join("..", config["data_folder"])
 static_data_folder = os.path.join("..", config["static_data_folder"])
 
@@ -45,6 +48,34 @@ today_str = datetime.date.today().isoformat()
 CHUNKS, = glob_wildcards(os.path.join(
     data_folder, "fasta_raw", "{chunk}.fa.gz"
 ))
+
+start_date_cutoff = None
+end_date_cutoff = None
+
+if config["start_date_cutoff"] is not None:
+    start_date_cutoff = pd.to_datetime(config["start_date_cutoff"])
+elif config["start_date_cutoff_days_ago"] is not None:
+    start_date_cutoff = (
+        pd.to_datetime(today_str) - 
+        pd.Timedelta(days=config["start_date_cutoff_days_ago"])
+    )
+
+if config["end_date_cutoff"] is not None:
+    end_date_cutoff = pd.to_datetime(config["end_date_cutoff"])
+elif config["end_date_cutoff_days_ago"] is not None:
+    end_date_cutoff = (
+        pd.to_datetime(today_str) - 
+        pd.Timedelta(days=config["end_date_cutoff_days_ago"])
+    )
+
+# Filter chunks by date
+if start_date_cutoff is not None:
+    print(f"Filtering out sequences from before {start_date_cutoff.isoformat()}")
+    CHUNKS = [c for c in CHUNKS if pd.to_datetime(c.split('_')[2]) > start_date_cutoff]
+
+if end_date_cutoff is not None:
+    print(f"Filtering out sequences from after {end_date_cutoff.isoformat()}")
+    CHUNKS = [c for c in CHUNKS if pd.to_datetime(c.split('_')[2]) < end_date_cutoff]
 
 SEGMENTS = config["segments"]
 SUBTYPES = [
@@ -211,13 +242,17 @@ rule sequence_manifest:
     output:
         manifest = os.path.join(data_folder, "sequence_manifest.csv")
     params:
-        processed_fasta_files = os.path.join(data_folder, "fasta_processed")
+        processed_fasta_files = os.path.join(data_folder, "fasta_processed"),
+        start_date_cutoff = f"--start-date-cutoff {start_date_cutoff.date().isoformat()}" if start_date_cutoff is not None else "",
+        end_date_cutoff = f"--end-date-cutoff {end_date_cutoff.date().isoformat()}" if end_date_cutoff is not None else ""
     shell:
         """
         python3 scripts/sequence_manifest.py \
             --reference {input.reference} \
             --fasta {params.processed_fasta_files} \
-            --out {output.manifest}
+            --out {output.manifest} \
+            {params.start_date_cutoff}
+            {params.end_date_cutoff}
         """
 
 

--- a/workflow_main/scripts/sequence_manifest.py
+++ b/workflow_main/scripts/sequence_manifest.py
@@ -98,6 +98,20 @@ def main():
         help="Path to reference JSON file",
     )
     parser.add_argument(
+        "--start-date-cutoff",
+        type=str,
+        required=False,
+        default=None,
+        help="Filter out sequences prior to this date"
+    )
+    parser.add_argument(
+        "--end-date-cutoff",
+        type=str,
+        required=False,
+        default=None,
+        help="Filter out sequences after this date"
+    )
+    parser.add_argument(
         "--out", type=str, required=True, help="Output manifest CSV file"
     )
 
@@ -140,6 +154,20 @@ def main():
         date=lambda x: x["file_name"].str.split("_").str.get(2),
         reference=lambda x: x["subtype"].map(subtype_refs),
     )
+
+    # Filter by date
+    pruned_manifest["date_obj"] = pd.to_datetime(pruned_manifest["date"])
+    if args.start_date_cutoff is not None:
+        print(f"Filtering out sequences from before {args.start_date_cutoff}")
+        pruned_manifest = pruned_manifest.loc[
+            pruned_manifest["date_obj"] > pd.to_datetime(args.start_date_cutoff)
+        ]
+    if args.end_date_cutoff is not None:
+        print(f"Filtering out sequences after {args.end_date_cutoff}")
+        pruned_manifest = pruned_manifest.loc[
+            pruned_manifest["date_obj"] < pd.to_datetime(args.end_date_cutoff)
+        ]
+    pruned_manifest.drop(columns=['date_obj'], inplace=True)
 
     pruned_manifest = pruned_manifest.explode("reference")
 


### PR DESCRIPTION
Add configuration option to truncate sequences in the main pipeline. Useful for creating date-limited datasets or to optimize pipeline running time (currently >24 hours for all SARS2 data)