### PR TITLE
Separate download for FASTA files via NCBI virus

### DIFF
--- a/workflow_rsv_genbank_ingest/Snakefile
+++ b/workflow_rsv_genbank_ingest/Snakefile
@@ -26,7 +26,7 @@ rule all:
     input:
         # Download latest data feed, process sequences
         os.path.join(
-            data_folder, "status", "download_" + today_str + ".done"
+            data_folder, "status", "download_metadata_" + today_str + ".done"
         ),
         os.path.join(
             data_folder, "status", "merge_sequences_" + today_str + ".done"
@@ -41,8 +41,8 @@ rule all:
         seq_by_subtype_tar = os.path.join(data_folder, 'seq_by_subtype.tar.gz')
 
 
-rule download_chunk:
-    """Download the data feed in chunks, to avoid timeouts.
+rule download_metadata_chunk:
+    """Download the data feed metadata in chunks, to avoid timeouts.
     """
     output:
         feed = os.path.join(data_folder, 'feed_chunks', 'feed_{chunk}.csv'),
@@ -51,12 +51,28 @@ rule download_chunk:
         end_time = lambda wildcards: chunks[int(wildcards.chunk)].end_time.strftime('%Y-%m-%dT%H:%M:%S.00Z')
     shell:
         """
-        python3 scripts/download.py \
+        python3 scripts/download_metadata.py \
             --start-time {params.start_time} --end-time {params.end_time} \
                 > {output.feed}
         """
 
-rule combine_download_chunks:
+
+rule download_sequence_chunk:
+    """Download the data feed metadata in chunks, to avoid timeouts.
+    """
+    output:
+        feed = os.path.join(data_folder, 'feed_chunks', 'feed_{chunk}.fasta'),
+    params:
+        start_time = lambda wildcards: chunks[int(wildcards.chunk)].start_time.strftime('%Y-%m-%dT%H:%M:%S.00Z'),
+        end_time = lambda wildcards: chunks[int(wildcards.chunk)].end_time.strftime('%Y-%m-%dT%H:%M:%S.00Z')
+    shell:
+        """
+        python3 scripts/download_sequences.py \
+            --start-time {params.start_time} --end-time {params.end_time} \
+                > {output.feed}
+        """
+
+rule combine_metadata_chunks:
     """Combine all the downloaded chunks into a single CSV file.
     Combining CSV files without duplicating header: https://apple.stackexchange.com/a/348619
     """
@@ -65,20 +81,34 @@ rule combine_download_chunks:
     params:
         chunk_glob = os.path.join(data_folder, 'feed_chunks', 'feed*.csv')
     output:
-        feed = os.path.join(data_folder, 'feed.csv'),
+        metadata_dirty = os.path.join(data_folder, 'metadata_dirty.csv'),
         status = touch(os.path.join(
-            data_folder, "status", "download_" + today_str + ".done"
+            data_folder, "status", "download_metadata_" + today_str + ".done"
         ))
     shell:
         """
-        awk '(NR == 1) || (FNR > 1)' {params.chunk_glob} > {output.feed}
+        awk '(NR == 1) || (FNR > 1)' {params.chunk_glob} > {output.metadata_dirty}
+        """
+
+rule combine_sequence_chunks:
+    """Combine all the downloaded chunks into a single FASTA file.
+    """
+    input:
+        chunks = expand(os.path.join(data_folder, 'feed_chunks', 'feed_{chunk}.fasta'), chunk=DL_CHUNKS)
+    params:
+        chunk_glob = os.path.join(data_folder, 'feed_chunks', 'feed*.fasta')
+    output:
+        feed = os.path.join(data_folder, 'feed.fasta'),
+    shell:
+        """
+        cat {params.chunk_glob} > {output.feed}
         """
 
 rule clean_metadata:
     """Clean metadata
     """
     input:
-        metadata_dirty = rules.combine_download_chunks.output.feed,
+        metadata_dirty = rules.combine_metadata_chunks.output.metadata_dirty,
     output:
         metadata_clean = os.path.join(data_folder, "metadata_no_subtype.csv")
     shell:
@@ -90,8 +120,8 @@ rule clean_metadata:
 
 rule write_all_fasta:
     input:
-        feed = rules.combine_download_chunks.output.feed,
-        download_status = rules.combine_download_chunks.output.status, # Force this step every day
+        feed = rules.combine_sequence_chunks.output.feed,
+        download_status = rules.combine_metadata_chunks.output.status, # Force this step every day
         metadata = rules.clean_metadata.output.metadata_clean
     output:
         sequences = os.path.join(data_folder, 'all_sequences.fa.gz')
@@ -141,7 +171,7 @@ rule split_sequences_by_subtype:
     """Split sequences by subtype
     """
     input:
-        feed = rules.combine_download_chunks.output.feed,
+        feed = rules.combine_sequence_chunks.output.feed,
         metadata = rules.join_subtype_assignments.output.metadata_plus_subtype
     output:
         seq_A = os.path.join(data_folder, 'seq_by_subtype', 'sequences_A.fa.gz'),
@@ -175,7 +205,7 @@ checkpoint chunk_sequences:
     hundreds of files, but the filesystem seems to be handling it well.
     """
     input:
-        feed = rules.combine_download_chunks.output.feed,
+        feed = rules.combine_sequence_chunks.output.feed,
         metadata = rules.join_subtype_assignments.output.metadata_plus_subtype,
     output:
         fasta = directory(os.path.join(data_folder, "fasta_temp"))

--- a/workflow_rsv_genbank_ingest/scripts/chunk_sequences.py
+++ b/workflow_rsv_genbank_ingest/scripts/chunk_sequences.py
@@ -38,7 +38,7 @@ def main():
     parser = argparse.ArgumentParser()
 
     parser.add_argument(
-        "--feed", type=str, required=True, help="Path to data feed csv file"
+        "--feed", type=str, required=True, help="Path to data feed FASTA file"
     )
     parser.add_argument(
         "--metadata-in", type=str, required=True, help="Path to metadata csv file"
@@ -74,16 +74,19 @@ def main():
     # Keep track of how far we're along the current chunk
     chunk_i = 0
 
-    with open(args.feed, "r", newline="") as fp_in:
+    # Read sequences
+    cur_entry = ""
+    cur_seq = ""
+
+    with open(args.feed, "rt", newline="") as fp_in:
         # Open up the initial fasta file for the first chunk
         fasta_by_month_subtype = defaultdict(list)
 
         line_counter = 0
         skip_counter = 0
 
-        feed_reader = csv.DictReader(fp_in, delimiter=",", quotechar='"')
-        for row in feed_reader:
-
+        lines = fp_in.readlines()
+        for i, line in enumerate(lines):
             # Flush results if chunk is full
             if chunk_i == args.chunk_size:
                 print("Writing {} sequences".format(chunk_i))
@@ -93,28 +96,45 @@ def main():
                 # Reset sequence dictionary
                 fasta_by_month_subtype = defaultdict(list)
 
-            # If this entry isn't present in the cleaned metadata, then skip
-            accession_id = row["genbank_accession"]
-            if accession_id not in metadata.index:
-                skip_counter += 1
+            # Strip whitespace
+            line = line.strip()
+
+            # Ignore empty lines that aren't the last line
+            if not line and i <= (len(lines) - 1):
                 continue
 
-            subtype = metadata.at[accession_id, "subtype"]
-            if not subtype:
-                skip_counter += 1
-                continue
+            # If not the name of an entry, add this line to the current sequence
+            # (some FASTA files will have multiple lines per sequence)
+            if line[0] != ">":
+                cur_seq = cur_seq + line
 
-            month = metadata.at[accession_id, "submission_date"][0:7]
+            # Start of another entry = end of the previous entry
+            if line[0] == ">" or i == (len(lines) - 1):
+                # Avoid capturing the first one and pushing an empty sequence
+                if cur_entry:
+                    accession_id = cur_entry.split("|")[0].strip()
+                    if accession_id in metadata.index:
+                        subtype = metadata.at[accession_id, "subtype"]
+                        if not subtype:
+                            skip_counter += 1
+                        else:
+                            month = metadata.at[accession_id, "submission_date"][0:7]
+                            # Store sequence in dictionary (By month, not day)
+                            fasta_by_month_subtype[(month, subtype)].append(
+                                (accession_id, cur_seq)
+                            )
+                            # Iterate the intra-chunk counter
+                            chunk_i += 1
+                            line_counter += 1
+                    else:
+                        skip_counter += 1
 
-            # Store sequence in dictionary (By month, not day)
-            fasta_by_month_subtype[(month, subtype)].append(
-                (accession_id, row["sequence"])
-            )
-
-            # Iterate the intra-chunk counter
-            chunk_i += 1
-
-            line_counter += 1
+                # Clear the entry and sequence
+                cur_entry = line[1:]
+                # Ignore anything past the first whitespace
+                if cur_entry:
+                    cur_entry = cur_entry.split()[0]
+                cur_seq = ""
 
         # Flush the last chunk
         print("Writing {} sequences".format(chunk_i))

--- a/workflow_rsv_genbank_ingest/scripts/download_metadata.py
+++ b/workflow_rsv_genbank_ingest/scripts/download_metadata.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# coding: utf-8
+
+"""
+(2020-12-21) Derived from:
+https://github.com/nextstrain/ncov-ingest: fetch-from-genbank script
+
+License is in LICENSE_NEXTSTRAIN, same folder
+
+------------------
+
+Download all RSV sequences and their curated metadata from GenBank via
+NCBI Virus.
+
+Outputs newline-delimited JSON records.
+
+The request this program makes is based on observing the network activity that
+
+    https://www.ncbi.nlm.nih.gov/labs/virus/vssi/#/virus?SeqType_s=Nucleotide&VirusLineage_ss=Severe%20acute%20respiratory%20syndrome%20coronavirus%202,%20taxid:2697049
+
+performs after clicking through the download interface.  Some tweaks were made
+by comparing different download requests and guessing, which allows us to
+download the metadata + sequence in the same request instead of two.
+"""
+
+
+import argparse
+import requests
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--start-time",
+        type=str,
+        required=True,
+        help="Start time in format YYYY-MM-DDTHH:MM:SS.00Z",
+    )
+    parser.add_argument(
+        "--end-time",
+        type=str,
+        required=True,
+        help="Start time in format YYYY-MM-DDTHH:MM:SS.00Z",
+    )
+    args = parser.parse_args()
+
+    endpoint = "https://www.ncbi.nlm.nih.gov/genomes/VirusVariation/vvsearch2/"
+    params = {
+        # Search criteria
+        "fq": [
+            '{!tag=SeqType_s}SeqType_s:("Nucleotide")',  # Nucleotide sequences (as opposed to protein)
+            "VirusLineageId_ss:(11250)",  # NCBI Taxon id for RSV
+            f"{{!tag=CreateDate_dt}}CreateDate_dt:([{args.start_time} TO {args.end_time}])",
+        ],
+        # Unclear, but seems necessary.
+        "q": "*:*",
+        # Response format
+        "cmd": "download",
+        "dlfmt": "csv",
+        "fl": ",".join(
+            ":".join(names)
+            for names in [
+                # Pairs of (output column name, source data field).  These are pulled
+                # from watching requests from the UI.
+                #
+                # XXX TODO: Is the full set source data fields documented
+                # somewhere?  Is there more info we could be pulling that'd be
+                # useful?
+                #   -trs, 13 May 2020
+                ("genbank_accession", "id"),
+                ("database", "SourceDB_s"),
+                ("strain", "Isolate_s"),
+                ("region", "Region_s"),
+                ("location", "CountryFull_s"),
+                ("collected", "CollectionDate_s"),
+                ("submitted", "CreateDate_dt"),
+                ("length", "SLen_i"),
+                ("host", "Host_s"),
+                ("isolation_source", "Isolation_csv"),
+                ("biosample_accession", "BioSample_s"),
+                ("title", "Definition_s"),
+                ("authors", "Authors_csv"),
+                ("publications", "PubMed_csv"),
+                # ("sequence", "Nucleotide_seq"),
+                ("protein_names", "ProtNames_ss"),
+            ]
+        ),
+        # Stable sort with newest last so diffs work nicely.  Columns are source
+        # data fields, not our output columns.
+        "sort": "SourceDB_s desc, CollectionDate_s asc, id asc",
+        # This isn't Entrez, but include the same email parameter it requires just
+        # to be nice.
+        "email": "covidcg@broadinstitute.org",
+    }
+
+    headers = {
+        "User-Agent": "https://github.com/vector-engineering/covid-cg (covidcg@broadinstitute.org)",
+    }
+
+    response = requests.get(endpoint, params=params, headers=headers, stream=True)
+    response.raise_for_status()
+
+    response_content = response.iter_content(chunk_size=1024, decode_unicode=True)
+
+    for chunk in response_content:
+        print(chunk, end="")
+
+
+if __name__ == "__main__":
+    main()

--- a/workflow_rsv_genbank_ingest/scripts/download_sequences.py
+++ b/workflow_rsv_genbank_ingest/scripts/download_sequences.py
@@ -21,6 +21,15 @@ The request this program makes is based on observing the network activity that
 performs after clicking through the download interface.  Some tweaks were made
 by comparing different download requests and guessing, which allows us to
 download the metadata + sequence in the same request instead of two.
+
+------------------
+
+Example download:
+
+https://www.ncbi.nlm.nih.gov/genomes/VirusVariation/vvsearch2/?fq=%7B!tag%3DSeqType_s%7DSeqType_s:(%22Nucleotide%22)&fq=VirusLineageId_ss:(208893)&cmd=download&sort=SourceDB_s%20desc,CreateDate_dt%20desc,id%20asc&dlfmt=fasta&fl=AccVer_s,Definition_s,Nucleotide_seq
+
+https://www.ncbi.nlm.nih.gov/labs/virus/vssi/#/virus?SeqType_s=Nucleotide&VirusLineage_ss=Human%20respiratory%20syncytial%20virus%20A,%20taxid:208893
+
 """
 
 
@@ -29,7 +38,6 @@ import requests
 
 
 def main():
-
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--start-time",
@@ -57,35 +65,8 @@ def main():
         "q": "*:*",
         # Response format
         "cmd": "download",
-        "dlfmt": "csv",
-        "fl": ",".join(
-            ":".join(names)
-            for names in [
-                # Pairs of (output column name, source data field).  These are pulled
-                # from watching requests from the UI.
-                #
-                # XXX TODO: Is the full set source data fields documented
-                # somewhere?  Is there more info we could be pulling that'd be
-                # useful?
-                #   -trs, 13 May 2020
-                ("genbank_accession", "id"),
-                ("database", "SourceDB_s"),
-                ("strain", "Isolate_s"),
-                ("region", "Region_s"),
-                ("location", "CountryFull_s"),
-                ("collected", "CollectionDate_s"),
-                ("submitted", "CreateDate_dt"),
-                ("length", "SLen_i"),
-                ("host", "Host_s"),
-                ("isolation_source", "Isolation_csv"),
-                ("biosample_accession", "BioSample_s"),
-                ("title", "Definition_s"),
-                ("authors", "Authors_csv"),
-                ("publications", "PubMed_csv"),
-                ("sequence", "Nucleotide_seq"),
-                ("protein_names", "ProtNames_ss"),
-            ]
-        ),
+        "dlfmt": "fasta",
+        "fl": ",".join(["id", "AccVer_s", "Definition_s", "Nucleotide_seq"]),
         # Stable sort with newest last so diffs work nicely.  Columns are source
         # data fields, not our output columns.
         "sort": "SourceDB_s desc, CollectionDate_s asc, id asc",

--- a/workflow_rsv_genbank_ingest/scripts/split_sequences_by_subtype.py
+++ b/workflow_rsv_genbank_ingest/scripts/split_sequences_by_subtype.py
@@ -11,7 +11,6 @@ csv.field_size_limit(sys.maxsize)
 
 
 def main():
-
     """
     python3 scripts/split_sequences_by_subtype.py \
             --feed {input.feed} \
@@ -24,7 +23,7 @@ def main():
 
     parser = argparse.ArgumentParser()
 
-    parser.add_argument("--feed", type=str, required=True, help="Input feed CSV")
+    parser.add_argument("--feed", type=str, required=True, help="Input feed FASTA")
     parser.add_argument(
         "--metadata", type=str, required=True, help="Input metadata + subtype CSV"
     )
@@ -44,23 +43,45 @@ def main():
     seq_a = gzip.open(args.out_A, "wt")
     seq_b = gzip.open(args.out_B, "wt")
 
-    with open(args.feed, "r", newline="") as fp_in:
-        feed_reader = csv.DictReader(fp_in, delimiter=",", quotechar='"')
-        for row in feed_reader:
+    # Read sequences
+    cur_entry = ""
+    cur_seq = ""
 
-            # If this entry isn't present in the cleaned metadata, then skip
-            accession_id = row["genbank_accession"]
-            if accession_id not in metadata.index:
+    with open(args.feed, "rt", newline="") as fp_in:
+        lines = fp_in.readlines()
+
+        for i, line in enumerate(lines):
+            # Strip whitespace
+            line = line.strip()
+
+            # Ignore empty lines that aren't the last line
+            if not line and i <= (len(lines) - 1):
                 continue
 
-            subtype = metadata.at[accession_id, "subtype"]
-            if not subtype:
-                continue
+            # If not the name of an entry, add this line to the current sequence
+            # (some FASTA files will have multiple lines per sequence)
+            if line[0] != ">":
+                cur_seq = cur_seq + line
 
-            if subtype == "A":
-                seq_a.write(">{}\n{}\n".format(accession_id, row["sequence"]))
-            else:
-                seq_b.write(">{}\n{}\n".format(accession_id, row["sequence"]))
+            # Start of another entry = end of the previous entry
+            if line[0] == ">" or i == (len(lines) - 1):
+                # Avoid capturing the first one and pushing an empty sequence
+                if cur_entry:
+                    accession_id = cur_entry.split("|")[0].strip()
+                    if accession_id in metadata.index:
+                        subtype = metadata.at[accession_id, "subtype"]
+                        if subtype:
+                            if subtype == "A":
+                                seq_a.write(">{}\n{}\n".format(accession_id, cur_seq))
+                            else:
+                                seq_b.write(">{}\n{}\n".format(accession_id, cur_seq))
+
+                # Clear the entry and sequence
+                cur_entry = line[1:]
+                # Ignore anything past the first whitespace
+                if cur_entry:
+                    cur_entry = cur_entry.split()[0]
+                cur_seq = ""
 
     seq_a.close()
     seq_b.close()

--- a/workflow_rsv_genbank_ingest/scripts/write_all_fasta.py
+++ b/workflow_rsv_genbank_ingest/scripts/write_all_fasta.py
@@ -9,30 +9,68 @@ import sys
 
 csv.field_size_limit(sys.maxsize)
 
+
 def main():
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('--feed', type=str, required=True, help='Feed CSV file')
-    parser.add_argument('--metadata-in', type=str, required=True, help='Path to metadata csv file')
-    parser.add_argument('--out', type=str, required=True, help='Output fasta file suffix')
+    parser.add_argument("--feed", type=str, required=True, help="Feed FASTA file")
+    parser.add_argument(
+        "--metadata-in", type=str, required=True, help="Path to metadata csv file"
+    )
+    parser.add_argument(
+        "--out", type=str, required=True, help="Output fasta file suffix"
+    )
 
     args = parser.parse_args()
 
     # Load metadata
-    metadata = pd.read_csv(args.metadata_in, index_col='Accession ID')
+    metadata = pd.read_csv(args.metadata_in, index_col="Accession ID")
 
-    with open(args.feed, "r", newline="") as fp_in, gzip.open(args.out, "at") as fp_out:
+    # Read sequences
+    cur_entry = ""
+    cur_seq = ""
 
-        feed_reader = csv.DictReader(fp_in, delimiter=",", quotechar='"')
-        for row in feed_reader:
+    write_count = 0
+    skip_count = 0
 
-            # If this entry isn't present in the cleaned metadata, then skip
-            accession_id = row['genbank_accession']
-            if accession_id not in metadata.index:
+    # with open(fasta_file, "rt", encoding="latin-1") as fp:
+    with open(args.feed, "rt", newline="") as fp_in, gzip.open(
+        args.out, "at"
+    ) as fp_out:
+        lines = fp_in.readlines()
+        for i, line in enumerate(lines):
+            # Strip whitespace
+            line = line.strip()
+
+            # Ignore empty lines that aren't the last line
+            if not line and i <= (len(lines) - 1):
                 continue
 
-            fp_out.write('>{}\n{}\n'.format(accession_id, row['sequence']))
+            # If not the name of an entry, add this line to the current sequence
+            # (some FASTA files will have multiple lines per sequence)
+            if line[0] != ">":
+                cur_seq = cur_seq + line
+
+            # Start of another entry = end of the previous entry
+            if line[0] == ">" or i == (len(lines) - 1):
+                # Avoid capturing the first one and pushing an empty sequence
+                if cur_entry:
+                    accession_id = cur_entry.split("|")[0].strip()
+                    if accession_id in metadata.index:
+                        write_count += 1
+                        fp_out.write(">{}\n{}\n".format(accession_id, cur_seq))
+                    else:
+                        skip_count += 1
+
+                # Clear the entry and sequence
+                cur_entry = line[1:]
+                # Ignore anything past the first whitespace
+                if cur_entry:
+                    cur_entry = cur_entry.split()[0]
+                cur_seq = ""
+
+    print(f"Wrote {write_count} entries, skipped {skip_count}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Nucleotide sequences seem to no longer get packaged with NCBI virus CSV downloads? Modified RSV pipeline to grab FASTA files as a separate job and merge them back into the pipeline