### PR TITLE
Fix: fill missing surveillance counts with 0 instead of lirping between known values

### DIFF
--- a/src/vega_specs/surveillance.vg.json
+++ b/src/vega_specs/surveillance.vg.json
@@ -190,6 +190,22 @@
           "as": "valid"
         },
         {
+          "type": "impute",
+          "groupby": ["group", "region"],
+          "key": "collection_period",
+          "field": "percent",
+          "method": "value",
+          "value": 0
+        },
+        {
+          "type": "impute",
+          "groupby": ["group", "region"],
+          "key": "collection_period",
+          "field": "count",
+          "method": "value",
+          "value": 0
+        },
+        {
           "type": "collect",
           "sort": {
             "field": ["region", "group", "collection_period"],

--- a/src/vega_specs/surveillance_standalone_rsv.vg.json
+++ b/src/vega_specs/surveillance_standalone_rsv.vg.json
@@ -193,6 +193,22 @@
           "as": "valid"
         },
         {
+          "type": "impute",
+          "groupby": ["group", "region"],
+          "key": "collection_period",
+          "field": "percent",
+          "method": "value",
+          "value": 0
+        },
+        {
+          "type": "impute",
+          "groupby": ["group", "region"],
+          "key": "collection_period",
+          "field": "count",
+          "method": "value",
+          "value": 0
+        },
+        {
           "type": "collect",
           "sort": {
             "field": ["region", "group", "collection_period"],


### PR DESCRIPTION
Current surveillance plot linearly interprets across missing values. Fix this to show percentages of 0 when no data is available.