### PR TITLE
Fix GenBank date format in ingest download reqs

### DIFF
--- a/workflow_flu_genbank_ingest/scripts/download_metadata.py
+++ b/workflow_flu_genbank_ingest/scripts/download_metadata.py
@@ -148,9 +148,7 @@ def main():
     )
     args = parser.parse_args()
 
-    # NCBI doesn't like an end date even close to today
-    # so set the maximum end date to today minus 14 days
-    max_date = (datetime.datetime.now() - datetime.timedelta(days=14)).isoformat()
+    max_date = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.00Z")
     if args.end_time > max_date:
         args.end_time = max_date
 

--- a/workflow_flu_genbank_ingest/scripts/download_sequences.py
+++ b/workflow_flu_genbank_ingest/scripts/download_sequences.py
@@ -56,9 +56,7 @@ def main():
     )
     args = parser.parse_args()
 
-    # NCBI doesn't like an end date even close to today
-    # so set the maximum end date to today minus 14 days
-    max_date = (datetime.datetime.now() - datetime.timedelta(days=14)).isoformat()
+    max_date = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.00Z")
     if args.end_time > max_date:
         args.end_time = max_date
 

--- a/workflow_rsv_genbank_ingest/scripts/download_metadata.py
+++ b/workflow_rsv_genbank_ingest/scripts/download_metadata.py
@@ -47,9 +47,7 @@ def main():
     )
     args = parser.parse_args()
 
-    # NCBI doesn't like an end date even close to today
-    # so set the maximum end date to today minus 14 days
-    max_date = (datetime.datetime.now() - datetime.timedelta(days=14)).isoformat()
+    max_date = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.00Z")
     if args.end_time > max_date:
         args.end_time = max_date
 

--- a/workflow_rsv_genbank_ingest/scripts/download_sequences.py
+++ b/workflow_rsv_genbank_ingest/scripts/download_sequences.py
@@ -56,9 +56,7 @@ def main():
     )
     args = parser.parse_args()
 
-    # NCBI doesn't like an end date even close to today
-    # so set the maximum end date to today minus 14 days
-    max_date = (datetime.datetime.now() - datetime.timedelta(days=14)).isoformat()
+    max_date = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.00Z")
     if args.end_time > max_date:
         args.end_time = max_date
 

--- a/workflow_sars2_genbank_ingest/scripts/download_metadata.py
+++ b/workflow_sars2_genbank_ingest/scripts/download_metadata.py
@@ -46,9 +46,7 @@ def main():
     )
     args = parser.parse_args()
 
-    # NCBI doesn't like an end date even close to today
-    # so set the maximum end date to today minus 14 days
-    max_date = (datetime.datetime.now() - datetime.timedelta(days=14)).isoformat()
+    max_date = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.00Z")
     if args.end_time > max_date:
         args.end_time = max_date
 

--- a/workflow_sars2_genbank_ingest/scripts/download_sequences.py
+++ b/workflow_sars2_genbank_ingest/scripts/download_sequences.py
@@ -56,9 +56,7 @@ def main():
     )
     args = parser.parse_args()
 
-    # NCBI doesn't like an end date even close to today
-    # so set the maximum end date to today minus 14 days
-    max_date = (datetime.datetime.now() - datetime.timedelta(days=14)).isoformat()
+    max_date = datetime.datetime.now().strftime("%Y-%m-%dT%H:%M:%S.00Z")
     if args.end_time > max_date:
         args.end_time = max_date
 


### PR DESCRIPTION
Previous GenBank download requests had malformed datetime strings when one date exceeded the maximum date (current date)