### PR TITLE
Mutation separation

### DIFF
--- a/src/utils/mutationUtils.js
+++ b/src/utils/mutationUtils.js
@@ -20,8 +20,17 @@ export const formatMutation = (mutationStr, dnaOrAa) => {
       return `${chunks[2]}${chunks[1]}${chunks[3]}`;
     }
   } else if (dnaOrAa === DNA_OR_AA.AA) {
+    let feature = chunks[0];
+    let pos = parseInt(chunks[1]);
     let ref = chunks[2];
     let alt = chunks[3];
+
+    // For mutations with multiple reference AAs affected, display
+    // the position as a range of affected positions
+    // e.g., LPPA24S --> LPPA24/27S
+    if (ref.length > 1) {
+      pos = `${pos}/${pos + ref.length - 1}`;
+    }
 
     // Translate stop codon from "_" to more conventional "*"
     if (ref === '_') {
@@ -44,6 +53,6 @@ export const formatMutation = (mutationStr, dnaOrAa) => {
       ref = '';
     }
 
-    return `${chunks[0]}:${ref}${chunks[1]}${alt}`;
+    return `${feature}:${ref}${pos}${alt}`;
   }
 };

--- a/workflow_main/scripts/build_full_dataframe.py
+++ b/workflow_main/scripts/build_full_dataframe.py
@@ -40,6 +40,34 @@ def main():
         v: k for k, v in metadata_map["protein_aa_mutation"].items()
     }
 
+    # Affected positions map
+    gene_aa_affected_positions_map = {}
+    for k, v in metadata_map["gene_aa_mutation"].items():
+        feature = k.split("|")[0]
+        pos = int(k.split("|")[1])
+        ref = k.split("|")[2]
+        gene_aa_affected_positions_map[v] = ";".join(
+            [f"{feature}|{x}" for x in range(pos, pos + len(ref))]
+        )
+
+    protein_aa_affected_positions_map = {}
+    for k, v in metadata_map["protein_aa_mutation"].items():
+        feature = k.split("|")[0]
+        pos = int(k.split("|")[1])
+        ref = k.split("|")[2]
+        protein_aa_affected_positions_map[v] = ";".join(
+            [f"{feature}|{x}" for x in range(pos, pos + len(ref))]
+        )
+
+    # Add affected positions to dataframe
+    df.loc[:, "gene_aa_affected_positions"] = df["gene_aa_mutation"].apply(
+        lambda x: ";".join([gene_aa_affected_positions_map[i] for i in x])
+    )
+    df.loc[:, "protein_aa_affected_positions"] = df["protein_aa_mutation"].apply(
+        lambda x: ";".join([protein_aa_affected_positions_map[i] for i in x])
+    )
+
+    # Convert mutation IDs back to mutation strings
     df.loc[:, "dna_mutation"] = df["dna_mutation"].apply(
         lambda x: ";".join([dna_mutation_map[i] for i in x])
     )
@@ -50,7 +78,7 @@ def main():
         lambda x: ";".join([protein_aa_mutation_map[i] for i in x])
     )
 
-    # Serialize coverage
+    # Serialize coverage data
     df.loc[:, "dna_range"] = df["dna_range"].apply(
         lambda rngs: ";".join([f"{rng[0]}-{rng[1]}" for rng in rngs])
     )

--- a/workflow_main/scripts/process_mutations.py
+++ b/workflow_main/scripts/process_mutations.py
@@ -19,7 +19,7 @@ def process_mutations(
     mode="dna",  # dna, gene_aa, protein_aa
 ):
     """Process mutation data
-    
+
     Parameters
     ----------
     manifest: pandas.DataFrame
@@ -30,7 +30,7 @@ def process_mutations(
         - Mutations must occur at least this many times to pass filters
     mode: string
         - dna, gene_aa, protein_aa
-    
+
     Returns
     -------
     out: tuple of pandas.DataFrames
@@ -120,10 +120,12 @@ def process_mutations(
     )
 
     # Map mutations to integer IDs
-    mutation_map = pd.Series(mutation_df["mutation_str"].unique())
+    mutation_to_id_map = pd.Series(mutation_df["mutation_str"].unique())
     # Flip index and values
-    mutation_map = pd.Series(mutation_map.index.values, index=mutation_map)
-    mutation_df["mutation_id"] = mutation_df["mutation_str"].map(mutation_map)
+    mutation_to_id_map = pd.Series(
+        mutation_to_id_map.index.values, index=mutation_to_id_map
+    )
+    mutation_df["mutation_id"] = mutation_df["mutation_str"].map(mutation_to_id_map)
 
     mutation_group_df = mutation_df.groupby(
         ["Accession ID", "reference"], as_index=False
@@ -141,11 +143,11 @@ def process_mutations(
     )
 
     # Fill NaNs with empty arrays
-    mutation_group_df.loc[
-        mutation_group_df["mutation_id"].isna(), "mutation_id"
-    ] = pd.Series(
-        [[]] * mutation_group_df["mutation_id"].isna().sum(),
-        index=mutation_group_df.index[mutation_group_df["mutation_id"].isna()],
+    mutation_group_df.loc[mutation_group_df["mutation_id"].isna(), "mutation_id"] = (
+        pd.Series(
+            [[]] * mutation_group_df["mutation_id"].isna().sum(),
+            index=mutation_group_df.index[mutation_group_df["mutation_id"].isna()],
+        )
     )
 
-    return mutation_group_df, mutation_map
+    return mutation_group_df, mutation_to_id_map


### PR DESCRIPTION
In the CSV data files themselves:
- Multiple deletions will be split up into single deletions
  - ∆HV69 → ∆H69, ∆V70
- Mutations will be “ungrouped” if possible
  - FR157SG → F157S, R158G
- Add `positions_affected` columns to `data_complete.csv` file, for easier searching of positions affected by mutations
  - For example, for sequence containing LPPA24S, positions 24, 25, 26, 27 are added to a list in a separate column.

On the website (UI changes only)
- Large mutations with coupled insertions/mutations (where the mutation site is not obvious) will be labeled with the position range rather than a simple position
  - LPPA24S → LPPA24/27S
