### PR TITLE
Flu genbank - sanitize segment metadata before integer casting

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -10,18 +10,10 @@ else
     echo "Building version: ${CG_VERSION}"
 fi
 
-# SARS2
-
 gcloud builds submit --config build/cloudbuild.yaml --substitutions=_TARGET="cg",_CONFIGFILE="config/config_sars2_gisaid.yaml",_TAG_NAME="${CG_VERSION}", . && \
 gcloud builds submit --config build/cloudbuild.yaml --substitutions=_TARGET="cg-genbank",_CONFIGFILE="config/config_sars2_genbank.yaml",_TAG_NAME="${CG_VERSION}" . && \
 gcloud builds submit --config build/cloudbuild.yaml --substitutions=_TARGET="cg-private",_CONFIGFILE="config/config_sars2_gisaid_private.yaml",_TAG_NAME="${CG_VERSION}" . && \
-gcloud builds submit --config build/cloudbuild.yaml --substitutions=_TARGET="cg-alpha",_CONFIGFILE="config/config_sars2_alpha.yaml",_TAG_NAME="${CG_VERSION}", .
-
-# RSV
-
-gcloud builds submit --config build/cloudbuild.yaml --substitutions=_TARGET="rsv",_CONFIGFILE="config/config_rsv_genbank.yaml",_TAG_NAME="${CG_VERSION}" .
-
-# FLU
-
-gcloud builds submit --config build/cloudbuild.yaml --substitutions=_TARGET="flu-gisaid",_CONFIGFILE="config/config_flu_gisaid.yaml",_TAG_NAME="${CG_VERSION}" .
+gcloud builds submit --config build/cloudbuild.yaml --substitutions=_TARGET="cg-alpha",_CONFIGFILE="config/config_sars2_alpha.yaml",_TAG_NAME="${CG_VERSION}", . && \
+gcloud builds submit --config build/cloudbuild.yaml --substitutions=_TARGET="rsv",_CONFIGFILE="config/config_rsv_genbank.yaml",_TAG_NAME="${CG_VERSION}" . && \
+gcloud builds submit --config build/cloudbuild.yaml --substitutions=_TARGET="flu-gisaid",_CONFIGFILE="config/config_flu_gisaid.yaml",_TAG_NAME="${CG_VERSION}" . && \
 gcloud builds submit --config build/cloudbuild.yaml --substitutions=_TARGET="flu-genbank",_CONFIGFILE="config/config_flu_genbank.yaml",_TAG_NAME="${CG_VERSION}" .

--- a/workflow_flu_genbank_ingest/scripts/clean_metadata.py
+++ b/workflow_flu_genbank_ingest/scripts/clean_metadata.py
@@ -563,6 +563,10 @@ def main():
     segment_df["segment_complete"] = segment_df["segments"].combine_first(
         segment_df["protein_segment"]
     )
+    segment_df["segment_complete"] = pd.to_numeric(
+        segment_df["segment_complete"], errors="coerce", downcast="integer"
+    )
+    print(f"Removing rows with malformed segments: {segment_df["segment_complete"].isna().sum()}")
     segment_df.drop(
         segment_df.index[segment_df["segment_complete"].isna()], inplace=True
     )


### PR DESCRIPTION
Data contamination in segment metadata was causing crashes - this fixes those errors